### PR TITLE
bug fix: getCell only searched on first row

### DIFF
--- a/src/SimpleXLSX.php
+++ b/src/SimpleXLSX.php
@@ -926,7 +926,7 @@ class SimpleXLSX {
 				if ( $curR === $R && $curC === $C ) {
 					return $this->value( $c, $format );
 				}
-				if ( $curR > $R || $curC > $C ){
+				if ( $curR > $R && $curC > $C ){
 					return null;
 				}
 				$curC++;


### PR DESCRIPTION
When calling getCell(), if cell was not found on first row, it would return null.
With this fix, it will successfully search on all rows until cell is found.