### PR TITLE
make compatible with older versions of php

### DIFF
--- a/src/SimpleXLSX.php
+++ b/src/SimpleXLSX.php
@@ -757,7 +757,7 @@ class SimpleXLSX {
 	public function dimension( $worksheetIndex = 0 ) {
 
 		if ( ( $ws = $this->worksheet( $worksheetIndex ) ) === false ) {
-			return [0,0];
+			return array(0,0);
 		}
 		/* @var SimpleXMLElement $ws */
 


### PR DESCRIPTION
return array(0,0) instead of [0,0] so it doesn't break for those of us stuck using older versions of php.