### PR TITLE
use shared string in date cell

### DIFF
--- a/src/SimpleXLSX.php
+++ b/src/SimpleXLSX.php
@@ -824,10 +824,9 @@ class SimpleXLSX {
 				$format = $this->cellFormats[ $s ]['format'];
 			}
 		}
-		if ( strpos( $format, 'm' ) !== false ) {
-			$dataType = 'd';
-		}
+
 		$value = '';
+
 		switch ( $dataType ) {
 			case 's':
 				// Value is a shared string


### PR DESCRIPTION
I had a date cell with an invalid value (so it referenced a shared string).
Instead of referencing the shared string, simplexlsx was creating a date cell in which the value of that date was a number. That number was the index of the shared string. 
The result of converting that number to date was that every date cell with an invalid date became a date in the year 1900.
Example: fill a date cell with an invalid date (ex: 19/19/2000).
Result: simplexlsx was returning a cell with a date with something like (1900-01-14).
 