### PR TITLE
Add new function to return rows with header value as array keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ XLSX only, MS Excel 97 php reader [here](https://github.com/shuchkin/simplexls)
 
 *Hey, bro, please ★ the package for my motivation :)* 
 
-## Basic Usage
+## Basic Usage 1
 ```php
 if ( $xlsx = SimpleXLSX::parse('book.xlsx') ) {
 	print_r( $xlsx->rows() );
@@ -38,10 +38,50 @@ Array
             [4] => USA
         )
 
+    [2] => Array
+        (
+            [0] => 908606664
+            [1] => Slinky Malinki
+            [2] => Lynley Dodd
+            [3] => Mallinson Rendel
+            [4] => NZ
+        )
+
 )
 ```
 ```
 // SimpleXLSX::parse( $filename, $is_data = false, $debug = false, $skip_empty_rows = false ): SimpleXLSX (or false)
+```
+
+## Basic Usage 2
+```php
+if ( $xlsx = SimpleXLSX::parse('book.xlsx') ) {
+    print_r( $xlsx->rowsWithHeader() );
+} else {
+    echo SimpleXLSX::parseError();
+}
+```
+```
+Array
+(
+    [1] => Array
+        (
+            [ISBN] => 618260307
+            [title] => The Hobbit
+            [author] => J. R. R. Tolkien
+            [publisher] => Houghton Mifflin
+            [ctry] => USA
+        )
+
+    [2] => Array
+        (
+            [ISBN] => 908606664
+            [title] => Slinky Malinki
+            [author] => Lynley Dodd
+            [publisher] => Mallinson Rendel
+            [ctry] => NZ
+        )
+)
 ```
 ## Installation
 The recommended way to install this library is [through Composer](https://getcomposer.org).

--- a/examples/02-rows_rowsWithHeader_rowsEx.php
+++ b/examples/02-rows_rowsWithHeader_rowsEx.php
@@ -13,6 +13,12 @@ if ( $xlsx = SimpleXLSX::parse('books.xlsx')) {
 	print_r( $xlsx->rows() );
 	echo '</pre>';
 
+	// ->rowsWithHeader()
+	echo '<h2>$xlsx->rowsWithHeader()</h2>';
+	echo '<pre>';
+	print_r( $xlsx->rowsWithHeader() );
+	echo '</pre>';
+
 	// ->rowsEx();
 	echo '<h2>$xlsx->rowsEx()</h2>';
 	echo '<pre>';

--- a/src/SimpleXLSX.php
+++ b/src/SimpleXLSX.php
@@ -692,7 +692,18 @@ class SimpleXLSX {
 			$curR ++;
 		}
 
-		return $rows;
+		//before return, Modify original result to produce array keys as values (rather then numbers)
+		// by taking array values of 1st array element, and combine them into next arrays as array keys:
+
+		foreach ($rows as $row) {
+
+			$excel_header = array_values($rows[0]); // 1st array element is the header of the excel file.
+
+			$rowWithKey[] = array_combine($excel_header, $row); // set the array keys from numbers to header values.
+			unset($rowWithKey[0]); // to avoid returning the header as 1st array element
+		}
+		return $rowWithKey;
+		// return $rows;
 	}
 
 	public function rowsEx( $worksheetIndex = 0 ) {

--- a/src/SimpleXLSX.php
+++ b/src/SimpleXLSX.php
@@ -692,6 +692,52 @@ class SimpleXLSX {
 			$curR ++;
 		}
 
+		return $rows;
+	}
+
+
+	public function rowsWithHeader( $worksheetIndex = 0 ) {
+
+		if ( ( $ws = $this->worksheet( $worksheetIndex ) ) === false ) {
+			return false;
+		}
+		$dim = $this->dimension( $worksheetIndex );
+		$numCols = $dim[0];
+		$numRows = $dim[1];
+
+		$emptyRow = array();
+		for( $i = 0; $i < $numCols; $i++) {
+			$emptyRow[] = '';
+		}
+
+		$rows = array();
+		for( $i = 0; $i < $numRows; $i++) {
+			$rows[] = $emptyRow;
+		}
+
+		$curR = 0;
+		/* @var SimpleXMLElement $ws */
+		foreach ( $ws->sheetData->row as $row ) {
+			$curC = 0;
+			foreach ( $row->c as $c ) {
+				// detect skipped cols
+				$idx = $this->getIndex( (string) $c['r'] );
+				$x = $idx[0];
+				$y = $idx[1];
+
+				if ( $x > -1 ) {
+					$curC = $x;
+					$curR = $y;
+				}
+
+				$rows[ $curR ][ $curC ] = $this->value( $c );
+
+				$curC++;
+			}
+
+			$curR ++;
+		}
+
 		//before return, Modify original result to produce array keys as values (rather then numbers)
 		// by taking array values of 1st array element, and combine them into next arrays as array keys:
 
@@ -702,8 +748,8 @@ class SimpleXLSX {
 			$rowWithKey[] = array_combine($excel_header, $row); // set the array keys from numbers to header values.
 			unset($rowWithKey[0]); // to avoid returning the header as 1st array element
 		}
+
 		return $rowWithKey;
-		// return $rows;
 	}
 
 	public function rowsEx( $worksheetIndex = 0 ) {

--- a/src/SimpleXLSX.php
+++ b/src/SimpleXLSX.php
@@ -695,7 +695,7 @@ class SimpleXLSX {
 		return $rows;
 	}
 
-
+	//Copied rows() with modification
 	public function rowsWithHeader( $worksheetIndex = 0 ) {
 
 		if ( ( $ws = $this->worksheet( $worksheetIndex ) ) === false ) {
@@ -738,18 +738,17 @@ class SimpleXLSX {
 			$curR ++;
 		}
 
-		//before return, Modify original result to produce array keys as values (rather then numbers)
-		// by taking array values of 1st array element, and combine them into next arrays as array keys:
+		// Produce array keys from the array values of 1st array element
 
 		foreach ($rows as $row) {
 
-			$excel_header = array_values($rows[0]); // 1st array element is the header of the excel file.
+			$excel_header = array_values($rows[0]);
 
-			$rowWithKey[] = array_combine($excel_header, $row); // set the array keys from numbers to header values.
-			unset($rowWithKey[0]); // to avoid returning the header as 1st array element
+			$rowsWithKey[] = array_combine($excel_header, $row); 
+			unset($rowsWithKey[0]); // to avoid returning the header as 1st array element
 		}
 
-		return $rowWithKey;
+		return $rowsWithKey;
 	}
 
 	public function rowsEx( $worksheetIndex = 0 ) {


### PR DESCRIPTION

* Modified rows method to return array keys values (rather then current numbers) and created a new function called rowsWithHeader()

   Purpose of this method is to make it easy for DB insertion upon parsing, rather then specifying column name in controllers every time you want to parse and insert to DB.

* Added The function into the php example file.

* Modified readme file by Adding new Basic usage example.