### PR TITLE
PHP 7.4 deprecated: offset access syntax with curly braces

### DIFF
--- a/src/SimpleXLSX.php
+++ b/src/SimpleXLSX.php
@@ -866,7 +866,7 @@ class SimpleXLSX {
 
 			for ( $i = $colLen - 1; $i >= 0; $i -- ) {
 				/** @noinspection PowerOperatorCanBeUsedInspection */
-				$index += ( ord( $col{$i} ) - 64 ) * pow( 26, $colLen - $i - 1 );
+				$index += ( ord( $col[$i] ) - 64 ) * pow( 26, $colLen - $i - 1 );
 			}
 
 			return array( $index - 1, $row - 1 );


### PR DESCRIPTION
Small fix to resolve PHP 7.4 deprecated notice