### PR TITLE
Return empty string for empty Date formatted cell

### DIFF
--- a/src/SimpleXLSX.php
+++ b/src/SimpleXLSX.php
@@ -882,8 +882,10 @@ class SimpleXLSX {
 
 				break;
 			case 'd':
-				// Value is a date
-				$value = $this->datetimeFormat ? gmdate( $this->datetimeFormat, $this->unixstamp( (float) $cell->v ) ) : (float) $cell->v;
+				// Value is a date and non-empty
+				if ( ! empty($cell->v) ) {
+					$value = $this->datetimeFormat ? gmdate( $this->datetimeFormat, $this->unixstamp( (float) $cell->v ) ) : (float) $cell->v;
+				}
 				break;
 
 


### PR DESCRIPTION
Fixes #70 

If the value of a Date formatted cell is empty, do not attempt to convert the value to a timestamp by calling `XLSX::unixstamp()` and `gmdate()` as this will return a value of 0 for the timestamp causing the value returned by `gmdate()` to be Unix epoch and not an empty value as expected.

Example Excel file: [Book1.xlsx](https://github.com/shuchkin/simplexlsx/files/4290720/Book1.xlsx)

Before patch note value of Row 3 Cell 2 is "1970-01-01 00:00:00"
```
Array
(
    [0] => Array
        (
            [0] =>
            [1] => Text
            [2] => Date
            [3] => Currency
            [4] => Number
        )

    [1] => Array
        (
            [0] => Filled
            [1] => Steve
            [2] => 2020-01-05 00:00:00
            [3] => 1
            [4] => 1
        )

    [2] => Array
        (
            [0] => Filled
            [1] => Steve
            [2] => 2020-01-06 00:00:00
            [3] => 100
            [4] => 100
        )

    [3] => Array
        (
            [0] => Empty
            [1] =>
            [2] => 1970-01-01 00:00:00
            [3] =>
            [4] =>
        )
)
```

After patch value of Row 3 Cell 2 is correctly an empty cell

```
Array
(
    [0] => Array
        (
            [0] =>
            [1] => Text
            [2] => Date
            [3] => Currency
            [4] => Number
        )

    [1] => Array
        (
            [0] => Filled
            [1] => Steve
            [2] => 2020-01-05 00:00:00
            [3] => 1
            [4] => 1
        )

    [2] => Array
        (
            [0] => Filled
            [1] => Steve
            [2] => 2020-01-06 00:00:00
            [3] => 100
            [4] => 100
        )

    [3] => Array
        (
            [0] => Empty
            [1] =>
            [2] =>
            [3] =>
            [4] =>
        )
)
```