### PR TITLE
Исправление SimpleXML parser error: Huge input lookup

### DIFF
--- a/src/SimpleXLSX.php
+++ b/src/SimpleXLSX.php
@@ -570,7 +570,7 @@ class SimpleXLSX {
 			if ( LIBXML_VERSION < 20900 && function_exists('libxml_disable_entity_loader') ) {
 				$_old = libxml_disable_entity_loader();
 			}
-			$entry_xmlobj = simplexml_load_string( $entry_xml );
+			$entry_xmlobj = simplexml_load_string( $entry_xml, 'SimpleXMLElement', LIBXML_COMPACT | LIBXML_PARSEHUGE );
 
 			if ( LIBXML_VERSION < 20900 && function_exists('libxml_disable_entity_loader')) {
 				/** @noinspection PhpUndefinedVariableInspection */


### PR DESCRIPTION
https://stackoverflow.com/questions/43133981/simplexml-parser-error-huge-input-lookup

Warning: simplexml_load_string(): Entity: line 922: parser error : internal error: Huge input lookup in /var/www/u23173/data/www/manguard.ru/cron_handlers/sheet_parser.php on line 572

Warning: simplexml_load_string(): кронштейн к стене, зарядный провод. Габарит in /var/www/u23173/data/www/manguard.ru/cron_handlers/sheet_parser.php on line 572

Warning: simplexml_load_string(): ^ in /var/www/u23173/data/www/manguard.ru/cron_handlers/sheet_parser.php on line 572
bool(false)


Линк на решение оставил.