### PR TITLE
fix dimensions calculation for rows with 1 column

### DIFF
--- a/src/SimpleXLSX.php
+++ b/src/SimpleXLSX.php
@@ -863,13 +863,11 @@ class SimpleXLSX
                 $idx = $this->getIndex((string)$c['r']);
                 $x = $idx[0];
                 $y = $idx[1];
-                if ($x > 0) {
-                    if ($x > $maxC) {
-                        $maxC = $x;
-                    }
-                    if ($y > $maxR) {
-                        $maxR = $y;
-                    }
+                if ($x > $maxC) {
+                    $maxC = $x;
+                }
+                if ($y > $maxR) {
+                    $maxR = $y;
                 }
             }
         }


### PR DESCRIPTION
Fixes #130 - which has a sample spreadsheet that I used to test my change.

The spreadsheet does have `<dimension ref="A1:A2384"/>`, but getEntryXML() removes the dimension as part of its "dirty skip empty rows".

Dimension calculations for sheets without $ws->dimension['ref']; fail to update the max col/row if there was only column A in the row, so if the sheet only has values in A the dimensions() would always be [1,1].

Not sure if a better alternative would be to stop getEntryXML() removing the dimension in the first place, but that code must be there for a reason, so I imagine that would break something else.
