### PR TITLE
Address implicit nullable parameter deprecation

### DIFF
--- a/src/SimpleXLSXEx.php
+++ b/src/SimpleXLSXEx.php
@@ -611,7 +611,7 @@ class SimpleXLSXEx
 
         return $r;
     }
-    public function getColorValue(SimpleXMLElement $a = null, $default = '')
+    public function getColorValue(?SimpleXMLElement $a = null, $default = '')
     {
         if ($a === null) {
             return $default;


### PR DESCRIPTION
Implicit nullable parameter declarations are deprecated in PHP 8.4, so the following output appears when using SimpleXLSX with PHP 8.4:

`Deprecated: Shuchkin\SimpleXLSXEx::getColorValue(): Implicitly marking parameter $a as nullable is deprecated, the explicit nullable type must be used instead in src/SimpleXLSXEx.php on line 614`

This updates the type of the `getColorValue` function's `$a` parameter to be
explicitly nullable.

It's worth noting that nullable type declarations were introduced in PHP 7.1, so this is only a solution if your PHP target is at or above 7.1. [For what it's worth, PHP 7.1 has been unsupported (EOL) since 2019-12-01.]