### PR TITLE
Update .gitattributes to exclude dev files from composer dist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/examples/ export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore


### PR DESCRIPTION
This avoids shipping dev/tooling files in the composer dist that aren't needed at runtime.

Last `.gitattributes` update was none. The files below have been added or modified since, and are still included in the composer dist:
- `/examples/ export-ignore` — last touched in ce6559b 2022-02-21
- `/.gitattributes export-ignore` — last touched in new
- `/.gitignore export-ignore` — last touched in new

Background reading: https://blog.madewithlove.be/post/gitattributes/